### PR TITLE
use docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,5 @@ RUN yum -y install ansible
 RUN yum install -y openssh-clients
 WORKDIR /ansible_practice
 VOLUME /ansible_practice
+
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+
+networks:
+  network_automation:
+    ipam:
+      driver: default
+      config:
+        - subnet: 10.0.0.0/24
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
       network_automation:
         ipv4_address: 10.0.0.3
 
+  ansible:
+    build:
+      context: .
+    image: ansible
+    command: tail -f /dev/null
+    volumes:
+    - ./ansible_practice:/ansible_practice
+    networks:
+      network_automation:
+        ipv4_address: 10.0.0.2
+
 networks:
   network_automation:
     ipam:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,14 @@
 version: '3'
+services:
+  vyos01:
+    image: higebu/vyos:latest
+    command: /sbin/init
+    volumes:
+    - /lib/modules:/lib/modules
+    privileged: true
+    networks:
+      network_automation:
+        ipv4_address: 10.0.0.3
 
 networks:
   network_automation:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,6 @@ services:
     build:
       context: .
     image: ansible
-    command: tail -f /dev/null
     volumes:
     - ./ansible_practice:/ansible_practice
     networks:


### PR DESCRIPTION
VyOSコンテナのデプロイと、AnsibleコンテナのビルドとデプロイをDocker Composeに対応しました。
手順2を`docker-compose.yml`のあるディレクトリに移動してから以下のコマンドに置き換えることができます。

```
$ docker-compose up -d
```

また、手順3以降のコンテナのシェルを起動するコマンドはそれぞれ以下のように置き換えれば他は同じようにEC2で動作します。
(コマンドを`docker-compose`に変更し、`-it`オプションを省略)

```diff
- docker exec -it vyos01 /bin/bash
+ docker-compose exec vyos01 /bin/bash
```

```diff
- docker exec -it ansible /bin/bash
+docker-compose exec ansible /bin/bash 
```

ただ、注意点としてAnsibleコンテナのビルドが終わるまでVyOSコンテナは起動しないので並行作業はできないです。
ビルド済みコンテナをDocker Hubにあらかじめ用意しておくと良いかもしれないです。

([ansible-runner](https://hub.docker.com/r/ansible/ansible-runner)が使えないか試してみましたが、公開イメージそのままだとparamikoが入ってなくてvyosモジュール動作せず。。コンテナ内で`pip3 install paramiko`すれば動きますが)